### PR TITLE
Cs feature weapon in hand

### DIFF
--- a/HeartOfRuin/Assets/InGameItems/Equipment/Weapons/DemoOneHandedWeapon.asset
+++ b/HeartOfRuin/Assets/InGameItems/Equipment/Weapons/DemoOneHandedWeapon.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   itemName: DEMO 1 HAND WEAPON
   itemDescription: Surely you arent strong enough to wield this?
   id: f8000098e2134ed0be5c93b27a6c98b2
-  itemMesh: {fileID: 4762471060866180446, guid: 4a779008c478f5041ab939af3ffb45ed, type: 3}
+  itemMesh: {fileID: 7763710965197221259, guid: 0b3566ccf7e1e5d4692032bcc6c4eb62, type: 3}
   maxStackSize: 1
   rarity: 5
   tags:
@@ -40,14 +40,14 @@ MonoBehaviour:
   BonusCriticalDamage: 1.5
   itemEffects: []
   weaponDamageScalings:
-    None: 0
-    Physical: 0
-    Magical: 0
-    True: 0
-    Fire: 0
-    Lightning: 0
-    Ice: 0
-    Earth: 0
-    Wind: 0
-    Water: 0
+    None: 1
+    Physical: 1
+    Magical: 1
+    True: 1
+    Fire: 1
+    Lightning: 1
+    Ice: 1
+    Earth: 1
+    Wind: 1
+    Water: 1
   weaponType: 0

--- a/HeartOfRuin/Assets/Prefabs/Characters/Player/Elf Player.prefab
+++ b/HeartOfRuin/Assets/Prefabs/Characters/Player/Elf Player.prefab
@@ -125,6 +125,7 @@ MonoBehaviour:
     Wind: 0
     Water: 0
   castComponent: {fileID: 1207980942263171655}
+  weaponAttachPoint: {fileID: 8624963137319489105}
   playerHUD: {fileID: 0}
 --- !u!114 &5568387887786979083
 MonoBehaviour:
@@ -196,7 +197,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Inventory
   inventoryName: 'Starting Equipment / Equipped items '
-  inventorySize: 7
+  inventorySize: 6
   startingItems:
   - item: {fileID: 11400000, guid: e272eeb5a4ba08e449cec92d127d9c3a, type: 2}
     quantity: 1
@@ -213,10 +214,7 @@ MonoBehaviour:
   - item: {fileID: 11400000, guid: 2f0cbcf653a3531409985d765491be11, type: 2}
     quantity: 1
     slotType: 4
-  - item: {fileID: 0}
-    quantity: 0
-    slotType: 6
-  - item: {fileID: 11400000, guid: 2c2abe593e0ad0046bfbd20ff96447c6, type: 2}
+  - item: {fileID: 11400000, guid: e684c293a4ae72a4991f9e20d0024da0, type: 2}
     quantity: 1
     slotType: 6
   itemDropPrefab: {fileID: 3675725128406392298, guid: d75e7c45fd8002c4e8d78e4da88b1104, type: 3}
@@ -1023,6 +1021,11 @@ Transform:
 --- !u!4 &6167431725955613883 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9faef6c86d7a6894791d0db73e19e4d4, type: 3}
+  m_PrefabInstance: {fileID: 5917069134154326864}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8624963137319489105 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2715566404302941441, guid: 9faef6c86d7a6894791d0db73e19e4d4, type: 3}
   m_PrefabInstance: {fileID: 5917069134154326864}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7633804015272764388

--- a/HeartOfRuin/Assets/Prefabs/Weapons/Old/Iron_Rapier.prefab
+++ b/HeartOfRuin/Assets/Prefabs/Weapons/Old/Iron_Rapier.prefab
@@ -12,6 +12,8 @@ GameObject:
   - component: {fileID: 3515794279534059810}
   - component: {fileID: 592921498653583033}
   - component: {fileID: 5673690103010194578}
+  - component: {fileID: 9025437691279150353}
+  - component: {fileID: 2335542677875022391}
   m_Layer: 0
   m_Name: Iron_Rapier
   m_TagString: Untagged
@@ -89,6 +91,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &5673690103010194578
 CapsuleCollider:
@@ -105,7 +108,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -113,3 +116,38 @@ CapsuleCollider:
   m_Height: 1.9382567
   m_Direction: 1
   m_Center: {x: 0, y: 0.73602664, z: -0.000000014901161}
+--- !u!114 &9025437691279150353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7763710965197221259}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 090fb96d13786254c8c54fe647d8862d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamageComponent
+  damageScaling:
+    None: 0
+    Physical: 0
+    Magical: 0
+    True: 0
+    Fire: 0
+    Lightning: 0
+    Ice: 0
+    Earth: 0
+    Wind: 0
+    Water: 0
+--- !u!114 &2335542677875022391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7763710965197221259}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 178d6345ff25f8c488329e295080b252, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterWeapon

--- a/HeartOfRuin/Assets/Scripts/Character.cs
+++ b/HeartOfRuin/Assets/Scripts/Character.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 [RequireComponent(typeof(BMD.CharacterController))] // Ensure that a CharacterController component is attached
@@ -17,6 +18,7 @@ public abstract class Character : MonoBehaviour
     [SerializeField] protected CharacterStats characterStats;
     [SerializeField] DamageStruct characterDamageBonusPercentage;
     [SerializeField] SpellCaster castComponent;
+    [SerializeField] GameObject weaponAttachPoint;
     #endregion
 
     #region Cached References
@@ -49,7 +51,7 @@ public abstract class Character : MonoBehaviour
 
     void SetupSignaling()
     {
-        controller.OnAttackPerformed += OnAttack; 
+        controller.OnAttackPerformed += OnAttack;
     }
     private void SetupInventory()
     {
@@ -148,7 +150,7 @@ public abstract class Character : MonoBehaviour
     }
     public void AddItemEffects(ItemEffect[] effects)
     {
-        if(effects == null) return;
+        if (effects == null) return;
         foreach (ItemEffect effect in effects)
         {
             activeEffects.Add(effect);
@@ -179,8 +181,46 @@ public abstract class Character : MonoBehaviour
         characterStats.setCriticalDamage(characterStats.getCriticalDamage() + equippedItem.GetBonusCriticalDamage());
         characterDamageBonusPercentage += equippedItem.GetDamageBonusPercentages();
 
+        if (equippedItem.GetItemMesh() != null && (equippedItem.GetEquipSlotType() == EquipSlotType.OneHand || equippedItem.GetEquipSlotType() == EquipSlotType.TwoHanded))
+        {
+            Debug.Log("Equipping weapon mesh");
+
+            // Fix: Iterate over child transforms instead of GetComponentsInChildren<GameObject>()
+            foreach (Transform childTransform in weaponAttachPoint.transform)
+            {
+                Debug.Log("Checking for weapon mesh to destroy");
+
+                CharacterWeapon temp = childTransform.GetComponent<CharacterWeapon>();
+
+                if (temp != null)
+                {
+                    Debug.Log("Destroying old weapon mesh");
+                    Destroy(childTransform.gameObject);
+                }
+            }
+
+            GameObject weapon = Instantiate(equippedItem.GetItemMesh(), weaponAttachPoint.transform);
+            DamageComponent tempDamageComp = weapon.GetComponent<DamageComponent>();
+            Weapon tempWeapon = equippedItem as Weapon;
+            CharacterWeapon tempCharWeapon = weapon.GetComponent<CharacterWeapon>();
+            if (tempDamageComp != null)
+            {
+                tempDamageComp.SetDamageScaling(tempWeapon.GetWeaponDamageScalings());
+            }
+            if (tempCharWeapon != null)
+            {
+                tempCharWeapon.SetParentCharacter(this);
+            }
+            weapon.transform.localPosition = Vector3.zero;
+            weapon.transform.localRotation = Quaternion.identity;
+            weapon.layer = gameObject.layer;
+
+            
+        }
+
         NotifyStatChange?.Invoke();
     }
+
     public void OnItemUnequipped(Item item)
     {
         EquippableItem equippedItem = (EquippableItem)item;
@@ -191,8 +231,21 @@ public abstract class Character : MonoBehaviour
         characterStats.setCriticalDamage(characterStats.getCriticalDamage() - equippedItem.GetBonusCriticalDamage());
         characterDamageBonusPercentage = characterDamageBonusPercentage - equippedItem.GetDamageBonusPercentages();
 
+        // Fix: Iterate over child transforms instead of GetComponentsInChildren<GameObject>()
+        foreach (Transform childTransform in weaponAttachPoint.transform)
+        {
+            CharacterWeapon temp = childTransform.GetComponent<CharacterWeapon>();
+
+            if (temp != null)
+            {
+                Destroy(childTransform.gameObject);
+            }
+        }
+
         NotifyStatChange?.Invoke();
     }
+
+
     public void OnAttack()
     {
         foreach (var effect in activeEffects)
@@ -209,7 +262,7 @@ public abstract class Character : MonoBehaviour
     }
     public void OnHitTarget(Character target)
     {
-        foreach(var effect in activeEffects)
+        foreach (var effect in activeEffects)
         {
             effect.OnAttackHitEffect(this, target);
         }
@@ -219,5 +272,4 @@ public abstract class Character : MonoBehaviour
     /// newState: 0 = no damage, 1 = player weapon damage
     /// </summary>
     /// <param name="newState"></param>
-  
 }

--- a/HeartOfRuin/Assets/Scripts/Character.cs
+++ b/HeartOfRuin/Assets/Scripts/Character.cs
@@ -25,7 +25,8 @@ public abstract class Character : MonoBehaviour
     protected BMD.CharacterController controller;
     CharacterStats baseStats;
     DamageStruct baseDamageBonusPercentage;
-
+    GameObject currentWeaponMesh;
+    EquippableItem currentVisualWeaponItem;
     #endregion
 
     #region Runtime Variables
@@ -171,6 +172,85 @@ public abstract class Character : MonoBehaviour
     {
         return characterDamageBonusPercentage;
     }
+
+    private void CheckAndRemoveExistingWeaponMesh()
+    {
+        foreach (Transform childTransform in weaponAttachPoint.transform)
+        {
+            Debug.Log("Checking for weapon mesh to destroy");
+
+            CharacterWeapon temp = childTransform.GetComponent<CharacterWeapon>();
+
+            if (temp != null)
+            {
+                Debug.Log("Destroying old weapon mesh");
+                Destroy(childTransform.gameObject);
+            }
+        }
+        currentWeaponMesh = null;
+        currentVisualWeaponItem = null;
+    }
+
+    private void InstanciateNewWeaponMesh(EquippableItem equippedItem)
+    {
+        GameObject weapon = Instantiate(equippedItem.GetItemMesh(), weaponAttachPoint.transform);
+        DamageComponent tempDamageComp = weapon.GetComponent<DamageComponent>();
+        Weapon tempWeapon = equippedItem as Weapon;
+        CharacterWeapon tempCharWeapon = weapon.GetComponent<CharacterWeapon>();
+        if (tempDamageComp != null)
+        {
+            tempDamageComp.SetDamageScaling(tempWeapon.GetWeaponDamageScalings());
+        }
+        if (tempCharWeapon != null)
+        {
+            tempCharWeapon.SetParentCharacter(this);
+        }
+        weapon.transform.localPosition = Vector3.zero;
+        weapon.transform.localRotation = Quaternion.Euler(0, 0, 90);
+
+        weapon.layer = gameObject.layer;
+
+        currentWeaponMesh = weapon;
+    }
+
+    private void EvaluateWeaponMesh()
+    {
+        if (equipmentSlots == null) return;
+
+        EquippableItem fallbackWeapon = null;
+        bool isCurrentStillEquipped = false;
+
+        foreach (ItemSlot slot in equipmentSlots.GetInventorySlots())
+        {
+            EquippableItem item = slot.GetItem() as EquippableItem;
+            if (item != null && item.GetItemMesh() != null && 
+               (item.GetEquipSlotType() == EquipSlotType.OneHand || item.GetEquipSlotType() == EquipSlotType.TwoHanded))
+            {
+                if (item == currentVisualWeaponItem)
+                {
+                    isCurrentStillEquipped = true;
+                }
+                else if (fallbackWeapon == null)
+                {
+                    fallbackWeapon = item;
+                }
+            }
+        }
+
+        if (isCurrentStillEquipped)
+        {
+            return;
+        }
+
+        CheckAndRemoveExistingWeaponMesh();
+
+        if (fallbackWeapon != null)
+        {
+            InstanciateNewWeaponMesh(fallbackWeapon);
+            currentVisualWeaponItem = fallbackWeapon;
+        }
+    }
+
     public void OnItemEquipped(Item item)
     {
         EquippableItem equippedItem = (EquippableItem)item;
@@ -181,42 +261,7 @@ public abstract class Character : MonoBehaviour
         characterStats.setCriticalDamage(characterStats.getCriticalDamage() + equippedItem.GetBonusCriticalDamage());
         characterDamageBonusPercentage += equippedItem.GetDamageBonusPercentages();
 
-        if (equippedItem.GetItemMesh() != null && (equippedItem.GetEquipSlotType() == EquipSlotType.OneHand || equippedItem.GetEquipSlotType() == EquipSlotType.TwoHanded))
-        {
-            Debug.Log("Equipping weapon mesh");
-
-            // Fix: Iterate over child transforms instead of GetComponentsInChildren<GameObject>()
-            foreach (Transform childTransform in weaponAttachPoint.transform)
-            {
-                Debug.Log("Checking for weapon mesh to destroy");
-
-                CharacterWeapon temp = childTransform.GetComponent<CharacterWeapon>();
-
-                if (temp != null)
-                {
-                    Debug.Log("Destroying old weapon mesh");
-                    Destroy(childTransform.gameObject);
-                }
-            }
-
-            GameObject weapon = Instantiate(equippedItem.GetItemMesh(), weaponAttachPoint.transform);
-            DamageComponent tempDamageComp = weapon.GetComponent<DamageComponent>();
-            Weapon tempWeapon = equippedItem as Weapon;
-            CharacterWeapon tempCharWeapon = weapon.GetComponent<CharacterWeapon>();
-            if (tempDamageComp != null)
-            {
-                tempDamageComp.SetDamageScaling(tempWeapon.GetWeaponDamageScalings());
-            }
-            if (tempCharWeapon != null)
-            {
-                tempCharWeapon.SetParentCharacter(this);
-            }
-            weapon.transform.localPosition = Vector3.zero;
-            weapon.transform.localRotation = Quaternion.identity;
-            weapon.layer = gameObject.layer;
-
-            
-        }
+        EvaluateWeaponMesh();
 
         NotifyStatChange?.Invoke();
     }
@@ -231,16 +276,7 @@ public abstract class Character : MonoBehaviour
         characterStats.setCriticalDamage(characterStats.getCriticalDamage() - equippedItem.GetBonusCriticalDamage());
         characterDamageBonusPercentage = characterDamageBonusPercentage - equippedItem.GetDamageBonusPercentages();
 
-        // Fix: Iterate over child transforms instead of GetComponentsInChildren<GameObject>()
-        foreach (Transform childTransform in weaponAttachPoint.transform)
-        {
-            CharacterWeapon temp = childTransform.GetComponent<CharacterWeapon>();
-
-            if (temp != null)
-            {
-                Destroy(childTransform.gameObject);
-            }
-        }
+        EvaluateWeaponMesh();
 
         NotifyStatChange?.Invoke();
     }
@@ -273,3 +309,4 @@ public abstract class Character : MonoBehaviour
     /// </summary>
     /// <param name="newState"></param>
 }
+        

--- a/HeartOfRuin/Assets/Scripts/Runtime/Character/CharacterWeapon.cs
+++ b/HeartOfRuin/Assets/Scripts/Runtime/Character/CharacterWeapon.cs
@@ -9,6 +9,11 @@ public class CharacterWeapon : MonoBehaviour
     #endregion
 
 
+    public void SetParentCharacter(Character character)
+    {
+        this.character = character;
+    }
+
     private void Start()
     {
         character = GetComponentInParent<Character>();
@@ -35,11 +40,12 @@ public class CharacterWeapon : MonoBehaviour
 
     private void HitWithWeapon(GameObject target) 
     {
+        if (character == null) return;
 
         Debug.Log("Hit object: " + target.name);
 
-        CharacterStats playerStats = GetComponentInParent<Character>()?.GetCharacterStats();
-        DamageStruct damageBonusPercentage = GetComponentInParent<Character>()?.GetCharacterDamageBonusPercentage() ?? new DamageStruct();
+        CharacterStats playerStats = character?.GetCharacterStats();
+        DamageStruct damageBonusPercentage = character?.GetCharacterDamageBonusPercentage() ?? new DamageStruct();
 
         DamageStruct damage = damageComponent.CalculatePlayerDamage(playerStats, damageBonusPercentage);
 

--- a/HeartOfRuin/ProjectSettings/TagManager.asset
+++ b/HeartOfRuin/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - CinemachineTarget
   - Attackable
   - UnboundedTerrain
+  - Weapon
   layers:
   - Default
   - TransparentFX

--- a/Testing/Callum/testLog_weapon_in_hand.md
+++ b/Testing/Callum/testLog_weapon_in_hand.md
@@ -1,0 +1,46 @@
+# Test Log - Unreal Engine Project
+
+This document tracks the testing of core features in the Unreal Engine project.
+
+## Status Key
+✅ - Passed | ⚠️ - Issues Found | ❌ - Failed | ⏳ - Not Tested | ✖ - Not Applicable
+
+---
+
+## Feature Implemented in This Pull Request
+| Feature | Test Case | Expected Result | Status |
+|---------|----------|----------------|--------|
+| Weapon in hand | does a weapon item's world mesh prefab appear in the characters hand when equipped | The weapon appears in hand | ✅ |
+| weapon in hand | does the weapon get removed when the weapon is unequipped | the weapon disappears from the hand | ✅ |
+| weapon in hand | does the weapon get swapped correctly when different weapons are swapped in the hand slot | the weapon prefab is correctly swapped (see notes) | ✅ |
+
+---
+
+## Impacted Features
+| Feature | Test Case | Expected Result | Status |
+|---------|----------|----------------|--------|
+| Character | Does the character still operate as normal with no issues? | The character operates as normal | ✅ |
+
+---
+
+## Full Game Loop Testing
+| Feature | Test Case | Expected Result | Status |
+|---------|----------|----------------|--------|
+| Game Start | Player enters game world correctly | No issues on load | ✅ |
+| Core Mechanics | Main gameplay mechanics function as intended | No critical failures | ✅ |
+| UI & Menus | All menus function correctly and transitions work smoothly | UI elements are visible and interactive | ✅ |
+| Win Condition | Game correctly identifies win state and triggers victory screen | Player receives proper feedback | ✅ |
+| Fail Condition | Game correctly identifies failure state and triggers game over | Player receives proper feedback | ✅ |
+| Performance | Frame rate remains stable throughout play session | No significant FPS drops | ✅ |
+
+---
+
+## Notes & Known Issues
+- No issues to note when used correctly.  Some weapons do not have a prefab set up or have weapon prefabs that do not use weapon components. WEAPON COMPONENT MUST BE ADDED TO THE WEAPON PREFAB BEFORE IT CAN BE USED 
+## How to Update
+- When a test is **completed**, replace ⏳ with ✅ (Pass), ⚠️ (Issues Found), or ❌ (Fail).
+- Leave notes on failed tests or necessary fixes in the Git commit messages.
+
+---
+
+**Commit Reference:** [Insert commit hash here]


### PR DESCRIPTION
Added the functionality of the a weapon item's "world mesh" prefab to be used as the actual weapon the player holds. Works as you would expect however weapons with incorrectly set up prefabs (e.g. the weapon prefab doesnt have a character weapon or damage component) may/will break things.

A pass over the database to set up all the weapons will be necessary