### PR TITLE
Potential fix to loading sequence bug(s) using artificial delays

### DIFF
--- a/HeartOfRuin/Assets/Scripts/Game Manager/LevelManager.cs
+++ b/HeartOfRuin/Assets/Scripts/Game Manager/LevelManager.cs
@@ -6,64 +6,154 @@ public class LevelManager : MonoBehaviour
 {
     private const string LoadingScreenSceneName = "LoadingScreen";
 
-    // Dummy MonoBehaviour to execute the Coroutine
+    private static float s_minimumLoadingDelay = 2.0f;
+    private static float s_LoadingScreenSettleDelay = 5.0f;
+
     private class CoroutineRunner : MonoBehaviour { }
 
     public static void LoadSceneAdditiveWithLoadingScreen(string sceneName)
     {
-        Debug.Log($"Starting loading sequence for scene: {sceneName}");
+        Debug.Log($"[LevelManager] Preparing to load scene: {sceneName}");
+        
+        // Validation check to see if scenes exist in the build settings
+        if (!Application.CanStreamedLevelBeLoaded(sceneName))
+        {
+            Debug.LogError($"[LevelManager] Cannot load scene '{sceneName}'. Is it added to the Build Settings?");
+            return;
+        }
+
+        if (!Application.CanStreamedLevelBeLoaded(LoadingScreenSceneName))
+        {
+            Debug.LogError($"[LevelManager] Cannot load loading screen '{LoadingScreenSceneName}'. Is it added to the Build Settings?");
+            return;
+        }
+
+        Debug.Log($"[LevelManager] Starting loading sequence for scene: {sceneName}");
         
         // Spawn a temporary runner to process the coroutine so we avoid needing an instance of LevelManager
         GameObject runnerObj = new GameObject("[LevelManager_CoroutineRunner]");
         DontDestroyOnLoad(runnerObj);
-        CoroutineRunner runner = runnerObj.AddComponent<CoroutineRunner>();
         
+        
+        CoroutineRunner runner = runnerObj.AddComponent<CoroutineRunner>();
         runner.StartCoroutine(LoadSceneSequence(sceneName, runnerObj));
     }
 
     private static IEnumerator LoadSceneSequence(string newSceneName, GameObject runnerObj)
     {
-        string currentMainScene = SceneManager.GetActiveScene().name;
+        float totalSequenceStartTime = Time.realtimeSinceStartup;
+        float stepStartTime;
 
-        // 1. Load the loading screen additively
-        Debug.Log("Loading loading screen...");
+        string currentMainScene = SceneManager.GetActiveScene().name;
+        Debug.Log($"[LevelManager] [{Time.realtimeSinceStartup:F2}s] Current active scene is: {currentMainScene}");
+
+        // load the loading screen additively.
+        stepStartTime = Time.realtimeSinceStartup;
+        Debug.Log($"[LevelManager] [{stepStartTime:F2}s] Step 1: Loading loading screen '{LoadingScreenSceneName}'...");
         AsyncOperation loadLoadingScreen = SceneManager.LoadSceneAsync(LoadingScreenSceneName, LoadSceneMode.Additive);
+        if (loadLoadingScreen == null)
+        {
+            Debug.LogError($"[LevelManager] Failed to start loading '{LoadingScreenSceneName}'. Aborting sequence.");
+            Destroy(runnerObj);
+            yield break;
+        }
+
         while (!loadLoadingScreen.isDone)
         {
             yield return null;
         }
+        Debug.Log($"[LevelManager] -> Loading screen loaded successfully in {Time.realtimeSinceStartup - stepStartTime:F3}s.");
 
-        // Set the loading screen as active so we can safely unload the previous main scene
-        SceneManager.SetActiveScene(SceneManager.GetSceneByName(LoadingScreenSceneName));   
+        // Set the loading screen as active.
+        Scene activeLoadingScreen = SceneManager.GetSceneByName(LoadingScreenSceneName);
+        bool setActiveResult = SceneManager.SetActiveScene(activeLoadingScreen);
+        Debug.Log($"[LevelManager] -> Setting active scene to '{LoadingScreenSceneName}': {(setActiveResult ? "SUCCESS" : "FAILED")}");
 
-        // 2. Unload the current main scene
-        Debug.Log("Unloading current scene...");
+        // Unload the current main scene
+        stepStartTime = Time.realtimeSinceStartup;
+        Debug.Log($"[LevelManager] [{stepStartTime:F2}s] Step 2: Unloading current scene '{currentMainScene}'...");
         AsyncOperation unloadCurrentScene = SceneManager.UnloadSceneAsync(currentMainScene);
-        while (!unloadCurrentScene.isDone)
+        if (unloadCurrentScene != null)
+        {
+            while (!unloadCurrentScene.isDone)
+            {
+                yield return null;
+            }
+            Debug.Log($"[LevelManager] -> Scene '{currentMainScene}' unloaded successfully in {Time.realtimeSinceStartup - stepStartTime:F3}s.");
+        }
+        else
+        {
+            Debug.LogWarning($"[LevelManager] -> Failed to unload '{currentMainScene}'. It might already be unloaded or invalid.");
+        }
+        
+        // Load the new scene additively
+        stepStartTime = Time.realtimeSinceStartup;
+        Debug.Log($"[LevelManager] [{stepStartTime:F2}s] Step 3: Loading new scene '{newSceneName}'...");
+        AsyncOperation loadNewScene = SceneManager.LoadSceneAsync(newSceneName, LoadSceneMode.Additive);
+        if (loadNewScene == null)
+        {
+            Debug.LogError($"[LevelManager] Failed to start loading new scene '{newSceneName}'. Aborting sequence.");
+            Destroy(runnerObj);
+            yield break;
+        }
+
+        // Prevent the new scene from activating its objects and cameras immediately
+        loadNewScene.allowSceneActivation = false;
+
+        // Wait until Unity has finished bringing the scene into memory (halts at 0.9 progress)
+        while (loadNewScene.progress < 0.9f)
         {
             yield return null;
         }
-        
-        // 3. Load the new scene additively
-        Debug.Log("Loading new scene...");
-        AsyncOperation loadNewScene = SceneManager.LoadSceneAsync(newSceneName, LoadSceneMode.Additive);
+
+        // Perform the delay BEFORE allowing the level to activate and show on screen
+        float elapsedSequenceTime = Time.realtimeSinceStartup - totalSequenceStartTime;
+        if (elapsedSequenceTime < s_minimumLoadingDelay)
+        {
+            float remainingDelay = s_minimumLoadingDelay - elapsedSequenceTime;
+            Debug.Log($"[LevelManager] Artificial Delay constraint not met. Delaying transition for an additional {remainingDelay:F2}s...");
+            yield return new WaitForSecondsRealtime(remainingDelay);
+        }
+
+        // Now it's safe to activate the scene visually
+        loadNewScene.allowSceneActivation = true;
+
         while (!loadNewScene.isDone)
         {
             yield return null;
         }
+        Debug.Log($"[LevelManager] -> New scene '{newSceneName}' loaded successfully in {Time.realtimeSinceStartup - stepStartTime:F3}s.");
 
         // Set the newly loaded scene as the active scene
-        SceneManager.SetActiveScene(SceneManager.GetSceneByName(newSceneName));
+        Scene newActiveScene = SceneManager.GetSceneByName(newSceneName);
+        bool setNewActiveResult = SceneManager.SetActiveScene(newActiveScene);
+        Debug.Log($"[LevelManager] -> Setting active scene to '{newSceneName}': {(setNewActiveResult ? "SUCCESS" : "FAILED")}");
 
-        // 4. Unload the loading screen
-        Debug.Log("Unloading loading screen...");
+        // Since we are using additive loading, the loading screen is still active and covering the screen, leverage this with another artificial delay to allow the new scene to fully initialize.
+        Debug.Log("[LevelManager] Holding loading screen briefly to allow new scene to settle...");
+        yield return new WaitForSecondsRealtime(s_LoadingScreenSettleDelay);
+
+        //Unload the loading screen post delay
+        stepStartTime = Time.realtimeSinceStartup;
+        Debug.Log($"[LevelManager] [{stepStartTime:F2}s] Step 4: Unloading loading screen '{LoadingScreenSceneName}'...");
         AsyncOperation unloadLoadingScreen = SceneManager.UnloadSceneAsync(LoadingScreenSceneName);
-        while (!unloadLoadingScreen.isDone)
+        if (unloadLoadingScreen != null)
         {
-            yield return null;
+            while (!unloadLoadingScreen.isDone)
+            {
+                yield return null;
+            }
+            Debug.Log($"[LevelManager] -> Loading screen unloaded successfully in {Time.realtimeSinceStartup - stepStartTime:F3}s.");
+        }
+        else
+        {
+            Debug.LogWarning($"[LevelManager] -> Failed to unload loading screen. It might already be unloaded.");
         }
 
-        // Finished execution, safely destroy the temporary runner
+        float totalDuration = Time.realtimeSinceStartup - totalSequenceStartTime;
+        Debug.Log($"[LevelManager] [{Time.realtimeSinceStartup:F2}s] Loading sequence complete. Total time taken: {totalDuration:F3}s.");
+
+        // Finished execution, safely destroy the temporary runner (which also securely destroys the fallback camera)
         if (runnerObj != null)
         {
             Destroy(runnerObj);
@@ -120,7 +210,7 @@ public class LevelManager : MonoBehaviour
         }
         else
         {
-            Debug.Log("No more levels to load. Returning to Main Menu.");
+            Debug.Log("[LevelManager] No more levels to load. Returning to Main Menu.");
             LoadMainMenu();
         }
     }

--- a/HeartOfRuin/Assets/_Scenes/LoadingScreen.unity
+++ b/HeartOfRuin/Assets/_Scenes/LoadingScreen.unity
@@ -301,7 +301,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0


### PR DESCRIPTION
Experimental loading sequence changes that will ideally need testing on different machines but appears to work for me.

Generic artificial delay seems to fix the bug preventing the loading screen from "not appearing" and makes the game feel generally more polished

Scene loading settle delay seems to fix the "no camera" bug upon entering level 1, this is the part i feel needs a little more testing but it appears to fix the issue on my machine and is easy

Additional debug output added to make the sequence easier to trace